### PR TITLE
refactor(msbuild): clean msbuild ouput

### DIFF
--- a/compiler/msbuild.vim
+++ b/compiler/msbuild.vim
@@ -5,7 +5,7 @@ let current_compiler = "msbuild"
 
 let s:cpo_save = &cpo
 set cpo-=C
-CompilerSet makeprg=msbuild
+CompilerSet makeprg=msbuild\ /nologo\ /v:q\ /property:GenerateFullPaths=true
 CompilerSet errorformat=\ %#%f(%l\\\,%c):\ %t%.%#:\ %m
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
remove logo, make verbosity quiet and generate full paths so quickfix window can jump there regardless of project structure

closes #1 